### PR TITLE
Correct YAML deploy error

### DIFF
--- a/vendor/syck_hack.rb
+++ b/vendor/syck_hack.rb
@@ -10,6 +10,9 @@
 # class no matter if the full yaml library has loaded or not.
 #
 
+$: << ENV['BUNDLER_LIB_PATH'] if ENV['BUNDLER_LIB_PATH']
+require 'bundler/psyched_yaml'
+
 module YAML
   # In newer 1.9.2, there is a Syck toplevel constant instead of it
   # being underneith YAML. If so, reference it back under YAML as


### PR DESCRIPTION
I was receiving "undefined method `to_yaml`" errors when deploying. Adding these lines from the most recent heroku ruby buildpack (https://github.com/heroku/heroku-buildpack-ruby/) resolved the issue.

Thanks for putting together this buildpack -- I hadn't planned on pdftk being an issue in our cedar migration so this was a huge help!
